### PR TITLE
Update for 2022 and move to proc_ops for 5.x kernels

### DIFF
--- a/README
+++ b/README
@@ -2,6 +2,6 @@ WARHW
 War Hardware kernel module
 
 Currently consumes memory in order to readily report the week that WARHW
-occurs in 2019.  Simply cat /proc/warhw to remind yourself.
+occurs in 2022.  Simply cat /proc/warhw to remind yourself.
 
 Patches welcome.  I encourage excessive expansion of this kernel module.

--- a/warhw.c
+++ b/warhw.c
@@ -33,7 +33,7 @@ MODULE_INFO(warhw, "War Hardware");
 
 static int warhw_proc_show(struct seq_file *m, void *v)
 {
-    seq_printf(m, "WARHW\n26-Oct-2020 through 30-Oct-2020\n");
+    seq_printf(m, "WARHW\n24-Oct-2022 through 28-Oct-2022\n");
     return 0;
 }
 
@@ -42,12 +42,11 @@ static int warhw_proc_open(struct inode *inode, struct file *file)
     return single_open(file, warhw_proc_show, NULL);
 }
 
-static const struct file_operations warhw_proc_fops = {
-    .owner   = THIS_MODULE,
-    .open    = warhw_proc_open,
-    .read    = seq_read,
-    .llseek  = seq_lseek,
-    .release = single_release,
+static const struct proc_ops warhw_proc_fops = {
+    .proc_open    = warhw_proc_open,
+    .proc_read    = seq_read,
+    .proc_lseek  = seq_lseek,
+    .proc_release = single_release,
 };
 
 static int __init warhw_init(void)


### PR DESCRIPTION
I had to boot with secureboot disabled to test, but it appears to work:

```
✔ ~/git/github.com/dcantrell/warhw [2022 L|✚ 2…16]
10:17 $ sudo insmod ./warhw.ko
[sudo] password for jim:
✔ ~/git/github.com/dcantrell/warhw [2022 L|✚ 2…16]
10:17 $ cat /proc/warhw
WARHW
24-Oct-2022 through 28-Oct-2022
✔ ~/git/github.com/dcantrell/warhw [2022 L|✚ 2…16]
```